### PR TITLE
Fixed NaN problem for 2x2 matrix with nonzero [1][1] element

### DIFF
--- a/cracks.cc
+++ b/cracks.cc
@@ -1335,7 +1335,8 @@ void eigen_vectors_and_values(
   // Compute eigenvectors
   Tensor<1,dim> E_eigenvector_1;
   Tensor<1,dim> E_eigenvector_2;
-  if (std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[0][0]))
+  if (std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[0][0]) 
+          || std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[1][1]))
     {
       // E is close to diagonal
       E_eigenvector_1[0]=0;


### PR DESCRIPTION
The current check was not thorough enough to correctly resolve eigenvalues for cases in which all entries apart from (1,1) are zero. This produced a NaN which caused downstream operations to breakdown.

Example of input that produces a Nan:
```
0    0
0    8
```

