### PR TITLE
Swapped eigenvectors for proper order

### DIFF
--- a/cracks.cc
+++ b/cracks.cc
@@ -1335,8 +1335,7 @@ void eigen_vectors_and_values(
   // Compute eigenvectors
   Tensor<1,dim> E_eigenvector_1;
   Tensor<1,dim> E_eigenvector_2;
-  if (std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[0][0]) 
-          || std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[1][1]))
+  if (std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[0][0]))
     {
       // E is close to diagonal
       E_eigenvector_1[0]=1;

--- a/cracks.cc
+++ b/cracks.cc
@@ -1335,7 +1335,8 @@ void eigen_vectors_and_values(
   // Compute eigenvectors
   Tensor<1,dim> E_eigenvector_1;
   Tensor<1,dim> E_eigenvector_2;
-  if (std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[0][0]))
+  if (std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[0][0]) 
+          || std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[1][1]))
     {
       // E is close to diagonal
       E_eigenvector_1[0]=0;

--- a/cracks.cc
+++ b/cracks.cc
@@ -1339,10 +1339,10 @@ void eigen_vectors_and_values(
           || std::abs(matrix[0][1]) < 1e-10*std::abs(matrix[1][1]))
     {
       // E is close to diagonal
-      E_eigenvector_1[0]=0;
-      E_eigenvector_1[1]=1;
-      E_eigenvector_2[0]=1;
-      E_eigenvector_2[1]=0;
+      E_eigenvector_1[0]=1;
+      E_eigenvector_1[1]=0;
+      E_eigenvector_2[0]=0;
+      E_eigenvector_2[1]=1;
     }
   else
     {


### PR DESCRIPTION
For the case of zero off-diagonal terms consider the following matrix:
```
5    0
0    0
```
The current setup will recognize `e1=5`, `e2=0` and populate the eigenvectors as:
```
ev1 = (0,1)
ev2 = (1,0)
```
Thus making `(0,1)` the eigenvector associated with the eigenvalue `5`. In reality, this should be the other way around. A simple swap fixes it. 